### PR TITLE
Update references to the vmware-govcd library

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ go:
 script:
 - "./build.sh"
 install:
-- git clone -b query_api --single-branch https://github.com/skyscape-cloud-services/vmware-govcd.git
-  $GOPATH/src/github.com/hmrc/vmware-govcd
 - go get -t ./...
 deploy:
   skip_cleanup: true

--- a/vcd-healthcheck.go
+++ b/vcd-healthcheck.go
@@ -12,7 +12,7 @@ import (
     "github.com/howeyc/gopass"
     "github.com/olekukonko/tablewriter"
     // "github.com/fatih/color"
-    types "github.com/hmrc/vmware-govcd/types/v56"
+    types "github.com/skyscape-cloud-services/vmware-govcd/types/v56"
 )
 
 // VERSION is set at build time by using the following: 

--- a/vcd-healthcheck.go
+++ b/vcd-healthcheck.go
@@ -8,7 +8,7 @@ import (
     "strings"
     "time"
 
-    "github.com/hmrc/vmware-govcd"
+    "github.com/skyscape-cloud-services/vmware-govcd"
     "github.com/howeyc/gopass"
     "github.com/olekukonko/tablewriter"
     // "github.com/fatih/color"


### PR DESCRIPTION
Until hmrc/vmware-govcd#5 is merged, pointing to skyscape's fork of the vmware-govcd library.
