### PR TITLE
OS-8 Revert to linking against hmrc/vmware-govcd

### DIFF
--- a/healthcheck/check-hardware-version.go
+++ b/healthcheck/check-hardware-version.go
@@ -2,7 +2,7 @@ package healthcheck
 
 import (
 	"fmt"
-	types "github.com/skyscape-cloud-services/vmware-govcd/types/v56"
+	types "github.com/hmrc/vmware-govcd/types/v56"
 )
 
 // HardwareVersion checks that the VM is configured with H/W Version 9

--- a/healthcheck/check-network-device.go
+++ b/healthcheck/check-network-device.go
@@ -2,7 +2,7 @@ package healthcheck
 
 import (
 	"fmt"
-	types "github.com/skyscape-cloud-services/vmware-govcd/types/v56"
+	types "github.com/hmrc/vmware-govcd/types/v56"
 )
 
 // NetworkDevice checks that the device type is VMXNET3

--- a/healthcheck/check-vm-snapshots.go
+++ b/healthcheck/check-vm-snapshots.go
@@ -3,7 +3,7 @@ package healthcheck
 import (
 	"fmt"
 	"time"
-	types "github.com/skyscape-cloud-services/vmware-govcd/types/v56"
+	types "github.com/hmrc/vmware-govcd/types/v56"
 )
 
 // VMSnapshots checks that the VM passed in does not have any snapshots older than 7 days

--- a/vcd-healthcheck.go
+++ b/vcd-healthcheck.go
@@ -7,12 +7,12 @@ import (
     "os"
     "strings"
 
-    "github.com/skyscape-cloud-services/vmware-govcd"
+    "github.com/hmrc/vmware-govcd"
     "github.com/howeyc/gopass"
     "github.com/olekukonko/tablewriter"
-    // "github.com/fatih/color"
     "github.com/skyscape-cloud-services/vcd-healthcheck/healthcheck"
-    types "github.com/skyscape-cloud-services/vmware-govcd/types/v56"
+
+    types "github.com/hmrc/vmware-govcd/types/v56"
 )
 
 // VERSION is set at build time by using the following: 


### PR DESCRIPTION
hmrc/vmware-govcd#5 has been merged, so link against the upstream code instead of our fork.
